### PR TITLE
replace numpy.bool with bool

### DIFF
--- a/ava_evaluation/metrics.py
+++ b/ava_evaluation/metrics.py
@@ -38,7 +38,7 @@ def compute_precision_recall(scores, labels, num_gt):
     """
     if (
         not isinstance(labels, np.ndarray)
-        or labels.dtype != np.bool
+        or labels.dtype != bool
         or len(labels.shape) != 1
     ):
         raise ValueError("labels must be single dimension bool numpy array")


### PR DESCRIPTION
Summary:
numpy.bool is long deprecated and removed starting numpy-1.20.0 [1]. This replaces all references with equivalent `bool` type using the following oneliner:
```
rg -l np.bool vision | grep .py | xargs perl -pi -e s,bnp.boolb,bool,
```
1. https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Reviewed By: florazzz

Differential Revision: D50426577

fbshipit-source-id: a13b3a2301b2ee827542578d752219077ad09ce7